### PR TITLE
Disable 2D gravity in ball and project

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -20,3 +20,7 @@ window/size/viewport_width=1024
 window/size/viewport_height=600
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
+
+[physics]
+
+2d/default_gravity=0

--- a/scripts/Ball.gd
+++ b/scripts/Ball.gd
@@ -8,6 +8,9 @@ signal shot_taken
 
 var dragging := false
 
+func _ready():
+    gravity_scale = 0
+
 func _unhandled_input(event):
     if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
         if event.pressed:


### PR DESCRIPTION
## Summary
- Stop ball gravity by setting `gravity_scale = 0` in its script
- Globally disable 2D gravity via `project.godot`

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fc369ced0832982c88586470a4e91