### PR TITLE
Replace guard textures with geometry

### DIFF
--- a/scenes/Game.tscn
+++ b/scenes/Game.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=11 format=3]
+[gd_scene load_steps=16 format=3]
 
 [ext_resource type="Texture2D" path="res://assets/ball.png" id="1"]
 [ext_resource type="Texture2D" path="res://assets/hole.png" id="2"]
 [ext_resource type="Script" path="res://scripts/Game.gd" id="3"]
 [ext_resource type="Script" path="res://scripts/Ball.gd" id="4"]
 [ext_resource type="Script" path="res://scripts/Hole.gd" id="5"]
+[ext_resource type="PackedScene" path="res://scenes/Guard.tscn" id="6"]
 
 [sub_resource type="RectangleShape2D" id="1"]
 size = Vector2(1000, 20)
@@ -22,6 +23,18 @@ radius = 18.0
 friction = 0.2
 bounce = 0.6
 
+[sub_resource type="OccluderPolygon2D" id="6"]
+polygon = PackedVector2Array(Vector2(-500, -10), Vector2(500, -10), Vector2(500, 10), Vector2(-500, 10))
+
+[sub_resource type="OccluderPolygon2D" id="7"]
+polygon = PackedVector2Array(Vector2(-500, -10), Vector2(500, -10), Vector2(500, 10), Vector2(-500, 10))
+
+[sub_resource type="OccluderPolygon2D" id="8"]
+polygon = PackedVector2Array(Vector2(-10, -280), Vector2(10, -280), Vector2(10, 280), Vector2(-10, 280))
+
+[sub_resource type="OccluderPolygon2D" id="9"]
+polygon = PackedVector2Array(Vector2(-10, -280), Vector2(10, -280), Vector2(10, 280), Vector2(-10, 280))
+
 [node name="Game" type="Node2D"]
 script = ExtResource("3")
 
@@ -38,11 +51,17 @@ position = Vector2(512, 10)
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Walls/Top"]
 shape = SubResource("1")
 
+[node name="LightOccluder2D" type="LightOccluder2D" parent="Walls/Top"]
+occluder = SubResource("6")
+
 [node name="Bottom" type="StaticBody2D" parent="Walls"]
 position = Vector2(512, 590)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Walls/Bottom"]
 shape = SubResource("1")
+
+[node name="LightOccluder2D" type="LightOccluder2D" parent="Walls/Bottom"]
+occluder = SubResource("7")
 
 [node name="Left" type="StaticBody2D" parent="Walls"]
 position = Vector2(10, 300)
@@ -50,11 +69,17 @@ position = Vector2(10, 300)
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Walls/Left"]
 shape = SubResource("2")
 
+[node name="LightOccluder2D" type="LightOccluder2D" parent="Walls/Left"]
+occluder = SubResource("8")
+
 [node name="Right" type="StaticBody2D" parent="Walls"]
 position = Vector2(1014, 300)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Walls/Right"]
 shape = SubResource("2")
+
+[node name="LightOccluder2D" type="LightOccluder2D" parent="Walls/Right"]
+occluder = SubResource("9")
 
 [node name="Ball" type="RigidBody2D" parent="."]
 position = Vector2(200, 300)
@@ -84,6 +109,10 @@ shape = SubResource("4")
 texture = ExtResource("2")
 centered = true
 modulate = Color(0, 0, 0, 1)
+
+[node name="Guard" parent="." instance=ExtResource("6")]
+position = Vector2(400, 300)
+patrol_points = PackedVector2Array(Vector2(400, 300), Vector2(600, 300))
 
 [node name="UI" type="CanvasLayer" parent="."]
 

--- a/scenes/Guard.tscn
+++ b/scenes/Guard.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/Guard.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(16, 16)
+
+[node name="Guard" type="CharacterBody2D"]
+script = ExtResource("1")
+
+[node name="Body" type="Polygon2D" parent="."]
+polygon = PackedVector2Array(Vector2(-8, -8), Vector2(8, -8), Vector2(8, 8), Vector2(-8, 8))
+color = Color(1, 0, 0, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")
+
+[node name="Light2D" type="Light2D" parent="."]
+color = Color(1, 1, 0, 1)
+energy = 1.5
+shadow_enabled = true

--- a/scripts/Guard.gd
+++ b/scripts/Guard.gd
@@ -1,0 +1,36 @@
+extends CharacterBody2D
+
+@export var patrol_points: Array[Vector2] = []
+@export var speed: float = 100.0
+
+var _current_index: int = 0
+@onready var light: Light2D = $Light2D
+
+func _ready() -> void:
+    _setup_flashlight()
+
+func _physics_process(delta: float) -> void:
+    if patrol_points.is_empty():
+        velocity = Vector2.ZERO
+        return
+
+    var target: Vector2 = patrol_points[_current_index]
+    var to_target: Vector2 = target - global_position
+    if to_target.length() < 5.0:
+        _current_index = (_current_index + 1) % patrol_points.size()
+        target = patrol_points[_current_index]
+        to_target = target - global_position
+    velocity = to_target.normalized() * speed
+    if velocity.length() > 0:
+        rotation = velocity.angle()
+    move_and_slide()
+
+func _setup_flashlight() -> void:
+    var grad := Gradient.new()
+    grad.colors = PackedColorArray([Color(1, 1, 0, 1), Color(1, 1, 0, 0)])
+    var tex := GradientTexture2D.new()
+    tex.gradient = grad
+    tex.width = 256
+    tex.height = 256
+    tex.fill = GradientTexture2D.FILL_CONICAL
+    light.texture = tex


### PR DESCRIPTION
## Summary
- Remove guard and flashlight PNG assets
- Render guard with a red Polygon2D and keep matching collision shape
- Generate a conical GradientTexture2D in script to power the flashlight

## Testing
- `godot --version` *(fails: command not found)*
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc85c2ed48329b2f9d1951c4e5e08