### PR TITLE
Use radial gradient cone shader for guard light

### DIFF
--- a/assets/flashlight_cone.gdshader
+++ b/assets/flashlight_cone.gdshader
@@ -1,0 +1,11 @@
+shader_type canvas_item;
+
+uniform float cone_angle = 0.5;
+
+void fragment() {
+    vec2 pos = UV - vec2(0.5);
+    float angle = atan(pos.y, pos.x);
+    float mask = step(abs(angle), cone_angle);
+    vec4 tex = texture(TEXTURE, UV);
+    COLOR = vec4(tex.rgb, tex.a * mask);
+}

--- a/scripts/Guard.gd
+++ b/scripts/Guard.gd
@@ -32,5 +32,8 @@ func _setup_flashlight() -> void:
     tex.gradient = grad
     tex.width = 256
     tex.height = 256
-    tex.fill = GradientTexture2D.FILL_CONICAL
+    tex.fill = GradientTexture2D.FILL_RADIAL
     light.texture = tex
+    var mat := ShaderMaterial.new()
+    mat.shader = load("res://assets/flashlight_cone.gdshader")
+    light.material = mat


### PR DESCRIPTION
## Summary
- Replace conical gradient with radial gradient and apply custom cone shader for the guard's flashlight.
- Add `flashlight_cone.gdshader` to mask the radial gradient using polar coordinates and assign it to the light.

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repository access)*
- `pip install gdtoolkit` *(fails: tunnel connection 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fe195eb148329b14b8dc0db8fedec