### PR TITLE
Fix unused delta parameter in Guard physics process

### DIFF
--- a/scripts/Guard.gd
+++ b/scripts/Guard.gd
@@ -9,7 +9,7 @@ var _current_index: int = 0
 func _ready() -> void:
     _setup_flashlight()
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
     if patrol_points.is_empty():
         velocity = Vector2.ZERO
         return


### PR DESCRIPTION
## Summary
- rename `_physics_process` parameter to `_delta` to silence unused variable warning

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fe4029d9c8329bc9764b980641cfa