### PR TITLE
Suppress unused signal warnings

### DIFF
--- a/scripts/Ball.gd
+++ b/scripts/Ball.gd
@@ -1,4 +1,5 @@
 extends RigidBody2D
+@warning_ignore("unused_signal")
 signal shot_taken
 
 @export var power_scale: float = 10.0

--- a/scripts/Hole.gd
+++ b/scripts/Hole.gd
@@ -1,4 +1,5 @@
 extends Area2D
+@warning_ignore("unused_signal")
 signal ball_sunk
 
 func _on_body_entered(body):


### PR DESCRIPTION
## Summary
- silence unused signal warnings in Ball and Hole scripts by adding `@warning_ignore("unused_signal")`

## Testing
- `godot --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689fe401787083299933777aed09c875